### PR TITLE
Bump td-spark 19.7.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sparklytd
 Title: Read and write data from/to Arm Treasure Data with sparklyr
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R: 
     person(given = "Aki",
            family = "Ariga",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,6 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1
 Imports:
-    sparklyr,
+    sparklyr (>= 1.0.4.9002),
     dplyr,
     DBI

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1,5 +1,5 @@
 spark_dependencies <- function(spark_version, scala_version, ...) {
-  td_spark_version = "1.1.0"
+  td_spark_version = "19.7.0"
 
   sparklyr::spark_dependency(
     jars = c(

--- a/R/spark_td.R
+++ b/R/spark_td.R
@@ -4,6 +4,7 @@
 #' this command enables to download jar within sparklytd directory.
 #'
 #' @param dest_path The destination path where jar will be downloaded to.
+#' @param force_download Flag for force download
 #'
 #' @examples
 #' \dontrun{
@@ -13,7 +14,7 @@
 #' @importFrom utils download.file
 #'
 #' @export
-download_jar <- function(dest_path = NULL) {
+download_jar <- function(dest_path = NULL, force_download = FALSE) {
   if (is.null(dest_path)) {
     dest_path <- file.path(system.file(package="sparklytd"), "java")
   }
@@ -22,7 +23,7 @@ download_jar <- function(dest_path = NULL) {
   download_url <- sprintf("https://s3.amazonaws.com/td-spark/td-spark-assembly_2.11-%s.jar", td_spark_version)
   dest_file <- file.path(dest_path, basename(download_url))
 
-  if (file.exists(dest_file)) {
+  if (file.exists(dest_file) && !force_download) {
     stop("jar is already downloaded. Abort.")
   }
 

--- a/R/spark_td.R
+++ b/R/spark_td.R
@@ -17,8 +17,9 @@ download_jar <- function(dest_path = NULL) {
   if (is.null(dest_path)) {
     dest_path <- file.path(system.file(package="sparklytd"), "java")
   }
+  td_spark_version = "19.7.0"
 
-  download_url <- "https://s3.amazonaws.com/td-spark/td-spark-assembly_2.11-1.1.0.jar"
+  download_url <- sprintf("https://s3.amazonaws.com/td-spark/td-spark-assembly_2.11-%s.jar", td_spark_version)
   dest_file <- file.path(dest_path, basename(download_url))
 
   if (file.exists(dest_file)) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,7 +42,7 @@ download_jar()
 default_conf <- spark_config()
 default_conf$spark.td.apikey=Sys.getenv("TD_API_KEY")
 default_conf$spark.serializer="org.apache.spark.serializer.KryoSerializer"
-default_conf$psark.sql.execution.arrow.enabled="true"
+default_conf$spark.sql.execution.arrow.enabled="true"
 
 sc <- spark_connect(master = "local", config = default_conf)
 ```


### PR DESCRIPTION
Note that spraklyr 1.0.4 on CRAN hasn't support Spark 2.4 yet as of now.